### PR TITLE
Remove commas from /info JSON

### DIFF
--- a/v0.10/info/index.html
+++ b/v0.10/info/index.html
@@ -8,16 +8,16 @@
         "0.10.0": "https://www.optimade.org/providers/optimade/v0.10/"
       },
       "formats": [
-        "json",
+        "json"
       ],
       "entry_types_by_format": {
-        "json": [],
+        "json": []
       },
       "available_endpoints": [
         "info",
         "links"
       ],
       "is_index": true
-    },
+    }
   }
 }


### PR DESCRIPTION
In the process of testing the validator from the python tools package as a GH action (that could be added to this repository), I've discovered that the current response at https://www.optimade.org/providers/info does not validate as JSON, due to some trailing commas. This PR fixes that.