### PR TITLE
Added GH action validator from optimade-python-tools

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,24 @@
+name: Scheduled validator
+
+on:
+  push:
+  #  schedule:
+  #   - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    name: OPTiMaDe validator
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install OPTiMaDe
+      run: |
+        python -m pip install --upgrade pip
+        pip install git+https://github.com/Materials-Consortia/optimade-python-tools
+    - name: Run validator
+      run: |
+        optimade_validator https://www.optimade.org/providers

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,4 +21,4 @@ jobs:
         pip install git+https://github.com/Materials-Consortia/optimade-python-tools
     - name: Run validator
       run: |
-        optimade_validator https://www.optimade.org/providers
+        optimade_validator --index https://www.optimade.org/providers

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,8 +2,6 @@ name: Scheduled validator
 
 on:
   push:
-  #  schedule:
-  #   - cron:  '0 0 * * *'
 
 jobs:
   validate:
@@ -19,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install git+https://github.com/Materials-Consortia/optimade-python-tools
-    - name: Run validator
+        pip install pytest
+    - name: Run validator on repository
       run: |
-        optimade_validator --index https://www.optimade.org/providers
+        py.test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
     - name: Install OPTiMaDe
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/Materials-Consortia/optimade-python-tools
+        pip install optimade
         pip install pytest
     - name: Run validator on repository
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,119 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# VSCode project settings
+.vscode
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# pytest
+.pytest_cache/
+
+.DS_Store
+.idea/
+
+Untitled.ipynb
+local_openapi.json
+local_index_openapi.json
+server.cfg

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import pathlib
+import json
+import unittest
+from optimade.models import ProviderResource, BaseInfoResource
+
+TOP_DIR = pathlib.Path(__file__).parent.parent
+VERSIONS = [v.parts[-1] for v in TOP_DIR.iterdir() if v.is_dir() and v.parts[-1].startswith('v')]
+
+
+class ProvidersValidator(unittest.TestCase):
+
+    def test_info(self):
+        """ Validates the index.html json fudge as a `BaseInfoResource` object. """
+        for v_ind, version in enumerate(VERSIONS):
+            path = pathlib.Path(f"/{TOP_DIR}/{version}/info/index.html").resolve()
+            with open(path, 'r') as f:
+                json_rep = json.load(f)
+            BaseInfoResource(**json_rep["data"])
+
+    def test_providers(self):
+        """ Validates the providers.json as a list of `Provider`s objects. """
+        for v_ind, version in enumerate(VERSIONS):
+            path = pathlib.Path(f"{TOP_DIR}/src/{version}/providers.json").resolve()
+            with open(path, 'r') as f:
+                json_rep = json.load(f)
+            print(json_rep)
+            for provider in json_rep["data"]:
+                ProviderResource(**provider)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3,7 +3,7 @@
 import pathlib
 import json
 import unittest
-from optimade.models import ProviderResource, BaseInfoResource
+from optimade.models import InfoResponse, LinksResponse
 
 TOP_DIR = pathlib.Path(__file__).parent.parent
 VERSIONS = [v.parts[-1] for v in TOP_DIR.iterdir() if v.is_dir() and v.parts[-1].startswith('v')]
@@ -17,7 +17,7 @@ class ProvidersValidator(unittest.TestCase):
             path = pathlib.Path(f"/{TOP_DIR}/{version}/info/index.html").resolve()
             with open(path, 'r') as f:
                 json_rep = json.load(f)
-            BaseInfoResource(**json_rep["data"])
+            InfoResponse(**json_rep)
 
     def test_providers(self):
         """ Validates the providers.json as a list of `Provider`s objects. """
@@ -25,6 +25,4 @@ class ProvidersValidator(unittest.TestCase):
             path = pathlib.Path(f"{TOP_DIR}/src/{version}/providers.json").resolve()
             with open(path, 'r') as f:
                 json_rep = json.load(f)
-            print(json_rep)
-            for provider in json_rep["data"]:
-                ProviderResource(**provider)
+            LinksResponse(**json_rep)


### PR DESCRIPTION
Closes #5 (hopefully). This PR checks all commits with the optimade-python-tools validator. NB: this validates the _URL_ https://optimade.org/providers and *not* the files in this repository. It wouldn't be too much extra work to write a little python script that uses the same validator tools on this repository directly.

One open question is whether it should be only run on push, or run every day (or some other period) to ensure that the server/domain is up.

Relevant lines of config:
https://github.com/Materials-Consortia/providers/blob/580ebec395bb9a060fb65130abcc37dfd5972a51/.github/workflows/validate.yml#L5-L6

Currently the validator will fail until #10 is merged. The error message at the moment is quite opaque as it is failing at such a fundamental level (unable to parse response from server as JSON), but I have an open PR at Materials-Consortia/optimade-python-tools#144 to improve this.

I'm trying to generalise this slightly so that the validator is sourced from e.g. `Materials-Consortia/optimade_validator_action` or some such repo, but passing parameters via GH doesn't seem to be trivial... My current (stalled) progress is at [ml-evs/autovalidate_optimade](https://github.com/ml-evs/autovalidate_optimade)