### PR TITLE
Fixes to available_api_versions

### DIFF
--- a/v0.10/info/index.html
+++ b/v0.10/info/index.html
@@ -4,9 +4,12 @@
     "id": "/",
     "attributes": {
       "api_version": "v0.10.0",
-      "available_api_versions": [{
-            "0.10.0": "https://www.optimade.org/providers/optimade/v0.10/"
-      }],
+      "available_api_versions": [
+        {
+          "url": "https://www.optimade.org/providers/optimade/v0.10/",
+          "version": "0.10.0"
+        }
+      ],
       "formats": [
         "json"
       ],

--- a/v0.10/info/index.html
+++ b/v0.10/info/index.html
@@ -4,9 +4,9 @@
     "id": "/",
     "attributes": {
       "api_version": "v0.10.0",
-      "available_api_versions": {
-        "0.10.0": "https://www.optimade.org/providers/optimade/v0.10/"
-      },
+      "available_api_versions": [{
+            "0.10.0": "https://www.optimade.org/providers/optimade/v0.10/"
+      }],
       "formats": [
         "json"
       ],


### PR DESCRIPTION
`available_api_versions` should be a list of dicts, not a single dict. This PR fixes that (needs to be merged before #11).