### PR TITLE
Change URLs to reflect new subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The list of OPTiMaDe providers keeps track of all reserved database-specific pre
 
 The list of providers is published in the form of a statically hosted OPTiMaDe Index Meta-Database here:
 
-- [https://providers.optimade.org/](https://providers.optimade.org/)
+- https://providers.optimade.org/
 
 If you specifically seek the current list of providers for the latest version of the OPTiMaDe specification, you can access it at this URL:
 
-- [https://providers.optimade.org/providers.json](https://providers.optimade.org/providers.json)
+- https://providers.optimade.org/providers.json
 
 If you seek the list of providers formatted according to a specific major version of the OPTiMaDe specification, you can access it using this URL:
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
+<a href="https://www.optimade.org/"><img src="https://avatars0.githubusercontent.com/u/23107754" align="left" width="10%" ></a>
+
 # OPTiMaDe Providers Index Meta-Database
 
 The list of OPTiMaDe providers keeps track of all reserved database-specific prefixes and the URLs to the index databases of all OPTiMaDe database providers that participate in the [OPTiMaDe network](https://www.optimade.org/).
 
 The list of providers is published in the form of a statically hosted OPTiMaDe Index Meta-Database here:
 
-- [https://www.optimade.org/providers/](https://www.optimade.org/providers/)
+- [https://providers.optimade.org/](https://providers.optimade.org/)
 
 If you specifically seek the current list of providers for the latest version of the OPTiMaDe specification, you can access it at this URL:
 
-- [https://www.optimade.org/providers/providers.json](https://www.optimade.org/providers/providers.json)
+- [https://providers.optimade.org/providers.json](https://providers.optimade.org/providers.json)
 
-If you seek the current list of providers for any older version of the OPTiMaDe specification, you can access it using this URL:
+If you seek the list of providers formatted according to a specific major version of the OPTiMaDe specification, you can access it using this URL:
 
-- [https://www.optimade.org/providers/*\<version\>*/links](https://www.optimade.org/providers/<version>/links)
+- [https://providers.optimade.org/*\<version\>*/links](https://providers.optimade.org/<version>/links)
 
+Where `<version>` designates a major version name of the OPTiMaDe specification, e.g., `v1`. 
 
 ## Repository organization
 
@@ -23,7 +26,7 @@ The repository is organized this way:
 
 - `/src/links/<version>/providers.json` is the current providers.json file formatted according to OPTiMaDe version `<version>` and any later version that uses a format that is backward compatible with this version.
 
-- `/src/links/<version>/info.json` is the proper response to the info endpoint formatted according to OPTiMaDe version `<version>` and any later version that uses a format that is backward compatible with this version.
+- `/src/info/<version>/info.json` is the proper response to the info endpoint formatted according to OPTiMaDe version `<version>` and any later version that uses a format that is backward compatible with this version.
 
 - `/_redirect` specify http rewrites to map index meta-database URLs `/<version>/info` and `/<version>/links` to the corresponding files under `src/`, as well as `/providers.json`.
 
@@ -31,6 +34,5 @@ The repository is organized this way:
 
 - `/providers.json` is a symbolic link continously updated to point at the latest version of the providers.json file under `/src/` to somewhat support hosting solutions that do not understand the instructions in `_redirect`.
 
-To update the list of providers, please file a pull-request against the repository.
-This pull-request MUST update ALL the provider.json files `src/links/<version>/providers.json`.
-(This way, the current list of providers is updated for implementations across all versions of the OPTiMaDe protocol.)
+Presently, only the `v1` version of the formats exist.
+Hence, to update the list of providers, file a pull-request against the repository to edit `/src/links/v1/providers.json`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you specifically seek the current list of providers for the latest version of
 
 If you seek the list of providers formatted according to a specific major version of the OPTiMaDe specification, you can access it using this URL:
 
-- [https://providers.optimade.org/*\<version\>*/links](https://providers.optimade.org/<version>/links)
+- [https://providers.optimade.org/*\<version\>*/links](https://providers.optimade.org/v1/links)
 
 Where `<version>` designates a major version name of the OPTiMaDe specification, e.g., `v1`. 
 

--- a/src/info/v1/index.html
+++ b/src/info/v1/index.html
@@ -1,1 +1,0 @@
-info.json

--- a/src/links/v1/index.html
+++ b/src/links/v1/index.html
@@ -1,1 +1,0 @@
-providers.json


### PR DESCRIPTION
We need to host the providers index meta-database differently from the OPTiMaDe main website to address Materials-Consortia/OPTiMaDe#236.

Hence, we now have a dedicated subdomain for hosting the providers list via Netlify: https://providers.optimade.org

This PR changes the README.txt to update this and make a few other minor adjustments to README.md based on comments in #14 that were not addressed there.