### PR TITLE
Fix URL links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The list of OPTiMaDe providers keeps track of all reserved database-specific pre
 
 The list of providers is published in the form of a statically hosted OPTiMaDe Index Meta-Database here:
 
-- https://providers.optimade.org/
+- [https://providers.optimade.org/](https://providers.optimade.org/)
 
 If you specifically seek the current list of providers for the latest version of the OPTiMaDe specification, you can access it at this URL:
 
-- https://providers.optimade.org/providers.json
+- [https://providers.optimade.org/providers.json](https://providers.optimade.org/providers.json)
 
 If you seek the list of providers formatted according to a specific major version of the OPTiMaDe specification, you can access it using this URL:
 


### PR DESCRIPTION
Fixes #17 

Apparently, for some reason, the markdown workflow that rendered README.md via netifly does not render raw URLs in markdown as links. This reverts the changes that removed the explicit markdown links.

This reverts commit cf168145727ba37e4a8d9368da6f0a283e741e82.

Preview is available at: https://deploy-preview-16--optimade-providers.netlify.com/
Compare with https://providers.optimade.org/