### PR TITLE
Add README.md text to help others host index meta-databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Hence, to update the list of providers, file a pull-request against the reposito
 
   - Make sure to update the URL in `available_api_versions` to point at your hosting location.
 
-- Edit `/src/info/v1/info.json` to point out your OPTiMaDe databases:
+- Edit `/src/info/v1/links.json` to point out your OPTiMaDe databases:
 
   - Put all your databases on the form:
     ```
@@ -85,6 +85,6 @@ Hence, to update the list of providers, file a pull-request against the reposito
     - Build commmand: `jekyll build`
     - Publish directory: `_site/`
 
-  - You are also recommended to set something sane for your subdomain in *Domain settings*, or even setup your own custom domain.
+  - You are also recommended to set your subdomain in *Domain settings*, or setup your own custom domain.
 
 - If you are a provider of OPTiMaDe databases and you have set up the index meta-database to point at them, please post a pull-request against [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers) to add the URL for your index meta-database to the central OPTiMaDe providers list.

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ Hence, to update the list of providers, file a pull-request against the reposito
       "id": "optimade_index",
       "attributes": {
         "name": "OPTiMaDe providers",
-	"description": "OPTiMaDe index meta-database of known providers",
+        "description": "OPTiMaDe index meta-database of known providers",
         "base_url": "https://providers.optimade.org",
         "homepage": "https://www.optimade.org"
       }
     }
     ```
 
-- Edit `README.md` to say who you are and what databases you index.
+- Edit `README.md` to say who you are and what databases you provide.
 
 - Configure your hosting provider to use your forked repository.
   The repository presently contains configuration files for Netlify, which you can set up as follows:

--- a/README.md
+++ b/README.md
@@ -36,3 +36,53 @@ The repository is organized this way:
 
 Presently, only the `v1` version of the formats exist.
 Hence, to update the list of providers, file a pull-request against the repository to edit `/src/links/v1/providers.json`.
+
+## Fork this repository to set up an index meta-database for your own databases
+
+- Click on the Fork button in GitHub and follow the instructions.
+- Edit `/src/info/v1/info.json` with your information:
+
+  - Make sure to update the URL in `available_api_versions` to point at your hosting location.
+
+- Edit `/src/info/v1/info.json` to point out your OPTiMaDe databases:
+
+  - Put all your databases on the form:
+    ```
+    {
+      "type": "child",
+      "id": "example_main",
+      "attributes": {
+        "name": "Example name",
+        "description": "Example database containing example entries",
+        "base_url": "https://www.example.com/optimade",
+        "homepage": "https://www.example.com"
+      }
+    }
+    ```
+
+  - Include also the following segment:
+    ```
+    {
+      "type": "parent",
+      "id": "optimade_index",
+      "attributes": {
+        "name": "OPTiMaDe providers",
+	"description": "OPTiMaDe index meta-database of known providers",
+        "base_url": "https://providers.optimade.org",
+        "homepage": "https://www.optimade.org"
+      }
+    }
+    ```
+
+- Edit `README.md` to say who you are and what databases you index.
+- Configure your hosting provider to use your forked repository.
+  The repository presently contains configuration files for Netlify, which you can set up as follows:
+
+  - Deploy using the *Netlify Continuous Deployment: GitHub* option, and give it access to your forked repository with the following settings:
+  
+    - Build commmand: `jekyll build`
+    - Publish directory: `_site/`
+
+  - You are also recommended to set something sane for your subdomain in *Domain settings*, or even setup your own custom domain.
+
+- If you are a provider of OPTiMaDe databases and you have set up the index meta-database to point at them, feel free to post a pull-request against [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers) to add the URL for your index meta-database to the OPTiMaDe central list of providers.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Hence, to update the list of providers, file a pull-request against the reposito
 ## Fork this repository to set up an index meta-database for your own databases
 
 - Click on the Fork button in GitHub and follow the instructions.
+
 - Edit `/src/info/v1/info.json` with your information:
 
   - Make sure to update the URL in `available_api_versions` to point at your hosting location.
@@ -75,14 +76,15 @@ Hence, to update the list of providers, file a pull-request against the reposito
     ```
 
 - Edit `README.md` to say who you are and what databases you index.
+
 - Configure your hosting provider to use your forked repository.
   The repository presently contains configuration files for Netlify, which you can set up as follows:
 
-  - Deploy using the *Netlify Continuous Deployment: GitHub* option, and give it access to your forked repository with the following settings:
+  - Deploy using the Netlify *Continuous Deployment: GitHub App* option, and give it access to your forked repository with the following settings:
   
     - Build commmand: `jekyll build`
     - Publish directory: `_site/`
 
   - You are also recommended to set something sane for your subdomain in *Domain settings*, or even setup your own custom domain.
 
-- If you are a provider of OPTiMaDe databases and you have set up the index meta-database to point at them, feel free to post a pull-request against [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers) to add the URL for your index meta-database to the OPTiMaDe central list of providers.
+- If you are a provider of OPTiMaDe databases and you have set up the index meta-database to point at them, please post a pull-request against [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers) to add the URL for your index meta-database to the central OPTiMaDe providers list.

--- a/README.md
+++ b/README.md
@@ -44,37 +44,11 @@ Hence, to update the list of providers, file a pull-request against the reposito
 
   - Make sure to update the URL in `available_api_versions` to point at your hosting location.
 
-- Edit `/src/info/v1/links.json` to point out your OPTiMaDe databases:
-
-  - Put all your databases on the form:
-    ```
-    {
-      "type": "child",
-      "id": "example_main",
-      "attributes": {
-        "name": "Example name",
-        "description": "Example database containing example entries",
-        "base_url": "https://www.example.com/optimade",
-        "homepage": "https://www.example.com"
-      }
-    }
-    ```
-
-  - Include also the following segment:
-    ```
-    {
-      "type": "parent",
-      "id": "optimade_index",
-      "attributes": {
-        "name": "OPTiMaDe providers",
-        "description": "OPTiMaDe index meta-database of known providers",
-        "base_url": "https://providers.optimade.org",
-        "homepage": "https://www.optimade.org"
-      }
-    }
-    ```
+- Copy the file `src/index-metadbs/exmpl/v1/links.json` to `/src/info/v1/links.json` and edit this template to supply information about your own databases.
 
 - Edit `README.md` to say who you are and what databases you provide.
+
+- Remove the directory 'src/static-index-metadbs'
 
 - Configure your hosting provider to use your forked repository.
   The repository presently contains configuration files for Netlify, which you can set up as follows:
@@ -84,6 +58,6 @@ Hence, to update the list of providers, file a pull-request against the reposito
     - Build commmand: `jekyll build`
     - Publish directory: `_site/`
 
-  - You are also recommended to set your subdomain in *Domain settings*, or setup your own custom domain.
+  - You are also recommended to configure a subdomain in *Domain settings* at Netlify, or setup your own custom domain.
 
-- If you are a provider of OPTiMaDe databases and you have set up the index meta-database to point at them, please post a pull-request against [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers) to add the URL for your index meta-database to the central OPTiMaDe providers list.
+- If you are a provider of OPTIMADE databases and you have set up the index meta-database to point at them, please post a pull-request against [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers) to add the URL for your index meta-database to the central OPTIMADE providers list.


### PR DESCRIPTION
This PR adds a segment of text to README.md that explains how one can easily fork this repository to host one's own index meta-database that fulfills the requirements to be added to OPTiMaDe's central list of providers.

A preview is visible at: https://deploy-preview-18--optimade-providers.netlify.com/