### PR TITLE
Switched odbx link to top-level index meta-db

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -96,7 +96,7 @@
       "attributes": {
         "name": "open database of xtals",
         "description": "A public database of crystal structures mostly derived from ab initio structure prediction from the group of Dr Andrew Morris at the University of Birmingham https://ajm143.github.io",
-        "base_url": "https://optimade.odbx.science",
+        "base_url": "https://optimade-index.odbx.science",
         "homepage": "https://odbx.science"
       }
     },


### PR DESCRIPTION
Pre-empting the index meta-db change, this PR changes the odbx base_url link to an index meta-database (SSL might take a few hours to figure itself out).