### PR TITLE
Update to 1.0.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ For convenience, you can also access the most recent list of providers in the fo
 
 You can contribute a new provider or amend the current information by creating a pull request to [the `providers` repository](https://github.com/Materials-Consortia/providers).
 
-
 ## Repository organization
 
 The OPTIMADE providers repository is hosted here: [https://github.com/Materials-Consortia/providers](https://github.com/Materials-Consortia/providers)
@@ -30,7 +29,7 @@ The repository is organized this way:
 - `/src/index-metadbs/<provider_name>/<version>/info.json` and `/src/index-metadbs/<provider_name>/<version>/links.json` are static Index Meta-Databases that are hosted in this repository for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain one on their own.
   See more details and instructions in `/src/index-metadbs/README.md`.
 
-- `/_redirect` specifies http rewrites to map index meta-database URLs `/<version>/info` and `/<version>/links` to the corresponding files under `src/`, as well as `/providers.json`.
+- `/_redirects` specifies http rewrites to map index meta-database URLs `/<version>/info` and `/<version>/links` to the corresponding files under `src/`, as well as `/providers.json`.
   It also creates `/index-metadbs/<provider_name>/<version>/info.json` and `/index-metadbs/<provider_name>/<version>/links.json` URLs to point to the corresponding files in the `/src/index-metadbs` subfolders.
   This is used by the deploy tool Netlify.
 

--- a/providers.json
+++ b/providers.json
@@ -1,0 +1,1 @@
+src/links/v1/providers.json

--- a/src/index-metadbs/README.md
+++ b/src/index-metadbs/README.md
@@ -33,14 +33,14 @@ Note that "changes" here refer solely to changes to the *list of sub-databases*;
 3. Adapt the content of the `info.json` file.
    In particular, you should change two fields:
 
-   - change the URL of the `available_api_versions` by replacing `exmpl` with your identifier: `http://providers.optimade.org/index-metadbs/exmpl2/v1/`
+   - change the URL of the `available_api_versions` by replacing `exmpl` with your identifier: `http://providers.optimade.org/index-metadbs/exmpl2/v1/`.
    - change the `id` inside `data -> relationships -> default -> data -> id` from `exmpl` to the correct ID from the list of links in the `links.json` file.
      As [explained in the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#base-info-endpoint), this should be the ID of the database that should be considered as the "default" sub-database by clients.
-     
-     If you only have one sub-database and you followed the instructions above, you should use here your provider identifier.
-     If you do not wish to have a default database, set the `relationships` value to `null`.
 
-4. In the top-level `providers.json` file, point the `base_url` of your provider to `http://providers.optimade.org/index-metadbs/exmpl/`.
+     If you only have one sub-database and you followed the instructions above, you should use here your provider identifier.
+     If you do not wish to have a default database, set the `relationships` value to an empty dictionary or set the value of `relationships -> default -> data` to `null`.
+
+4. In the top-level `providers.json` file, point the `base_url` of your provider to `http://providers.optimade.org/index-metadbs/exmpl2/`.
 
 5. Create a pull request, and check that all automated continuous-integration tests pass.
    Also, you can check that the new Index Meta-Database properly works at the expected link using the Netlify preview (just click on the `netlify/optimade-providers/deploy-preview` entry of the GitHub checks that will appear in the GitHub PR Conversation page after a few seconds).

--- a/src/index-metadbs/cod/v1/info.json
+++ b/src/index-metadbs/cod/v1/info.json
@@ -3,7 +3,7 @@
       "attributes" : {
          "available_api_versions" : [
             {
-               "version" : "1.0.0",
+               "version" : "1.0.0-rc.2",
                "url" : "http://providers.optimade.org/index-metadbs/cod/v1/"
             }
          ],
@@ -18,7 +18,7 @@
             "info",
             "links"
          ],
-         "api_version" : "v1.0.0"
+         "api_version" : "1.0.0-rc.2"
       },
       "type" : "info",
       "relationships" : {

--- a/src/index-metadbs/exmpl/v1/info.json
+++ b/src/index-metadbs/exmpl/v1/info.json
@@ -3,7 +3,7 @@
       "attributes" : {
          "available_api_versions" : [
             {
-               "version" : "1.0.0",
+               "version" : "1.0.0-rc.2",
                "url" : "http://providers.optimade.org/index-metadbs/exmpl/v1/"
             }
          ],
@@ -18,7 +18,7 @@
             "info",
             "links"
          ],
-         "api_version" : "v1.0.0"
+         "api_version" : "1.0.0-rc.2"
       },
       "type" : "info",
       "relationships" : {

--- a/src/index-metadbs/tcod/v1/info.json
+++ b/src/index-metadbs/tcod/v1/info.json
@@ -3,7 +3,7 @@
       "attributes" : {
          "available_api_versions" : [
             {
-               "version" : "1.0.0",
+               "version" : "1.0.0-rc.2",
                "url" : "http://providers.optimade.org/index-metadbs/tcod/v1/"
             }
          ],
@@ -18,13 +18,13 @@
             "info",
             "links"
          ],
-         "api_version" : "v1.0.0"
+         "api_version" : "1.0.0-rc.2"
       },
       "type" : "info",
       "relationships" : {
          "default" : {
             "data" : {
-               "id" : "cod",
+               "id" : "tcod",
                "type" : "links"
             }
          }

--- a/src/index-metadbs/tcod/v1/links.json
+++ b/src/index-metadbs/tcod/v1/links.json
@@ -1,7 +1,7 @@
 {
    "data" : [
       {
-         "id" : "cod",
+         "id" : "tcod",
          "type" : "links",
          "attributes" : {
             "name": "Theoretical Crystallography Open Database",

--- a/src/info/v1/info.json
+++ b/src/info/v1/info.json
@@ -3,11 +3,11 @@
     "type": "info",
     "id": "/",
     "attributes": {
-      "api_version": "1.0.0",
+      "api_version": "1.0.0-rc.2",
       "available_api_versions": [
         {
           "url": "https://www.optimade.org/providers/optimade/v1/",
-          "version": "1.0.0"
+          "version": "1.0.0-rc.2"
         }
       ],
       "formats": [

--- a/src/info/v1/info.json
+++ b/src/info/v1/info.json
@@ -2,6 +2,7 @@
   "data": {
     "type": "info",
     "id": "/",
+    "relationships": {},
     "attributes": {
       "api_version": "1.0.0-rc.2",
       "available_api_versions": [

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -125,7 +125,7 @@
       "type": "links",
       "id": "optimade",
       "attributes": {
-        "name": "OPTiMaDe implementations and libraries",
+        "name": "OPTIMADE implementations and libraries",
         "description": "Prefix for implementation-specific identifiers used in API implementations and libraries provided at https://github.com/Materials-Consortia",
         "base_url": null,
         "homepage": "https://www.optimade.org",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -21,7 +21,7 @@ def query_optimade(url):
     This is important to allow testing of new endpoints before the PR
     is merged in GitHub (and only after things are merged in the main branch,
     they will appear on `providers.optimade.org`)
-    
+
     :param url: a string with the URL to fetch
     :return: the raw content.
     :raise urllib.error.HTTPError: if the page is not found. Note that this exception

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,7 +11,9 @@ from optimade.models import IndexInfoResponse, LinksResponse, Link
 
 TOP_DIR = pathlib.Path(__file__).parent.parent
 
-apply_v0_workarounds = True # To be disabled if/when we do not wish to allow to point to v0 endpoints
+# To be disabled if/when we do not wish to allow to point to v0 endpoints
+apply_v0_workarounds = True
+
 
 def query_optimade(url):
     """Perform a URL request to the given URL endpoint.
@@ -39,65 +41,78 @@ def query_optimade(url):
         ctx.verify_mode = ssl.CERT_NONE
 
     parsed_url = urllib.parse.urlparse(url)
-    if parsed_url.netloc == 'providers.optimade.org':
+    if parsed_url.netloc == "providers.optimade.org":
         # Strip initial /
-        path = parsed_url.path[1:] if parsed_url.path.startswith('/') else parsed_url.path
+        path = (
+            parsed_url.path[1:] if parsed_url.path.startswith("/") else parsed_url.path
+        )
         # Remove any pending slashes
-        path =  path[:-1] if path.endswith('/') else path
+        path = path[:-1] if path.endswith("/") else path
         # Append the .json extension
         path += ".json"
         # Create the abs path to the file
-        file_path = TOP_DIR / 'src' / path
+        file_path = TOP_DIR / "src" / path
         try:
             with open(file_path) as fhandle:
                 response_content = fhandle.read()
         except FileNotFoundError:
             raise urllib.error.HTTPError(
-                url=url, code=404, msg="HTTP Error 404: Not Found", hdrs="", fp="")
+                url=url, code=404, msg="HTTP Error 404: Not Found", hdrs="", fp=""
+            )
     else:
         with urllib.request.urlopen(url, context=ctx) as url_response:
             response_content = url_response.read()
-    
+
     return response_content
 
 
 class ProvidersValidator(unittest.TestCase):
-
     def test_info(self):
         """ Validates the index.html json fudge as a `BaseInfoResource` object. """
-        info_dir = TOP_DIR / 'src' / 'info'
+        info_dir = TOP_DIR / "src" / "info"
         versions = [
-            v.parts[-1] for v in info_dir.iterdir()
-            if v.is_dir() and v.parts[-1].startswith('v')
+            v.parts[-1]
+            for v in info_dir.iterdir()
+            if v.is_dir() and v.parts[-1].startswith("v")
         ]
         for version in versions:
             path = pathlib.Path(f"/{TOP_DIR}/src/info/{version}/info.json").resolve()
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 json_rep = json.load(f)
             IndexInfoResponse(**json_rep)
 
-
     def test_providers(self):
         """ Validates the providers.json as a list of `Provider`s objects. """
-        links_dir = TOP_DIR / 'src' / 'links'
-        versions = [v.parts[-1] for v in links_dir.iterdir() if v.is_dir() and v.parts[-1].startswith('v')]
+        links_dir = TOP_DIR / "src" / "links"
+        versions = [
+            v.parts[-1]
+            for v in links_dir.iterdir()
+            if v.is_dir() and v.parts[-1].startswith("v")
+        ]
         for version in versions:
-            path = pathlib.Path(f"{TOP_DIR}/src/links/{version}/providers.json").resolve()
-            with open(path, 'r') as f:
+            path = pathlib.Path(
+                f"{TOP_DIR}/src/links/{version}/providers.json"
+            ).resolve()
+            with open(path, "r") as f:
                 json_rep = json.load(f)
             LinksResponse(**json_rep)
 
- 
     def test_index_metadb(self):
         """ Validates that all (non-null) entries in providers.json point to an index meta-db. """
         # We collect all errors and report all of them at the end, see below
         problems = []
 
-        links_dir = TOP_DIR / 'src' / 'links'
-        versions = [v.parts[-1] for v in links_dir.iterdir() if v.is_dir() and v.parts[-1].startswith('v')]
+        links_dir = TOP_DIR / "src" / "links"
+        versions = [
+            v.parts[-1]
+            for v in links_dir.iterdir()
+            if v.is_dir() and v.parts[-1].startswith("v")
+        ]
         for version in versions:
-            path = pathlib.Path(f"{TOP_DIR}/src/links/{version}/providers.json").resolve()
-            with open(path, 'r') as f:
+            path = pathlib.Path(
+                f"{TOP_DIR}/src/links/{version}/providers.json"
+            ).resolve()
+            with open(path, "r") as f:
                 json_rep = json.load(f)
             response = LinksResponse(**json_rep)
             for entry in response.data:
@@ -112,48 +127,67 @@ class ProvidersValidator(unittest.TestCase):
                         if isinstance(entry.attributes.base_url, Link)
                         else entry.attributes.base_url
                     )
-                    info_endpoint = f'{entry_base_url}/{version}/info'
-                    tested_info_endpoints = [info_endpoint]                    
+                    info_endpoint = f"{entry_base_url}/{version}/info"
+                    tested_info_endpoints = [info_endpoint]
                     try:
                         try:
                             response_content = query_optimade(info_endpoint)
                         except urllib.error.HTTPError as exc:
-                            if apply_v0_workarounds and version == 'v1' and exc.code == 404:
+                            if (
+                                apply_v0_workarounds
+                                and version == "v1"
+                                and exc.code == 404
+                            ):
                                 try:
                                     # Temporary workaround for optimade-python-tools while v1 is released
-                                    info_endpoint = f'{entry_base_url}/v0.10/info'
+                                    info_endpoint = f"{entry_base_url}/v0.10/info"
                                     tested_info_endpoints.append(info_endpoint)
                                     response_content = query_optimade(info_endpoint)
                                 except urllib.error.HTTPError as exc:
                                     # Temporary workaround for nomad that uses v0 as a prefix
-                                    info_endpoint = f'{entry_base_url}/v0/info'
+                                    info_endpoint = f"{entry_base_url}/v0/info"
                                     tested_info_endpoints.append(info_endpoint)
-                                    response_content = query_optimade(info_endpoint)                              
+                                    response_content = query_optimade(info_endpoint)
                             else:
                                 raise
                     except urllib.error.HTTPError as exc:
-                        fallback_string = "" if len(tested_info_endpoints) == 1 else f" (I tried all these URLs: {tested_info_endpoints})"
-                        problems.append(f'Provider "{entry_id}" {info_endpoint} endpoint is not reachable{fallback_string}. Error: {str(exc)}')
+                        fallback_string = (
+                            ""
+                            if len(tested_info_endpoints) == 1
+                            else f" (I tried all these URLs: {tested_info_endpoints})"
+                        )
+                        problems.append(
+                            f'Provider "{entry_id}" {info_endpoint} endpoint is not reachable{fallback_string}. Error: {str(exc)}'
+                        )
                         continue
 
                     try:
-                        info_response = IndexInfoResponse(**json.loads(response_content))
+                        info_response = IndexInfoResponse(
+                            **json.loads(response_content)
+                        )
                     except Exception as exc:
-                        problems.append(f'Provider "{entry_id}": {info_endpoint} endpoint has problems during validation.\nError message:\n{str(exc)}')
+                        problems.append(
+                            f'Provider "{entry_id}": {info_endpoint} endpoint has problems during validation.\nError message:\n{str(exc)}'
+                        )
                         continue
 
                     # If unspecified, it should be assumed as False, according to the OPTIMADE specs
-                    is_index = info_response.data.attributes.dict().get('is_index', False)
+                    is_index = info_response.data.attributes.dict().get(
+                        "is_index", False
+                    )
                     if not is_index:
                         print(f"  > PROBLEM DETECTED with provider '{entry_id}'.")
                         print(response_content)
-                        problems.append(f'Provider "{entry_id}" is NOT providing an index meta-database at {info_endpoint}')
+                        problems.append(
+                            f'Provider "{entry_id}" is NOT providing an index meta-database at {info_endpoint}'
+                        )
                         continue
-                
-                    print(f'[INFO] Provider "{entry_id}" ({version}) validated correctly ({info_endpoint})')
-                                
+
+                    print(
+                        f'[INFO] Provider "{entry_id}" ({version}) validated correctly ({info_endpoint})'
+                    )
+
         # I am collecting all problems and printing at the end because in this way we get a full overview
-        # of the 
         if problems:
             err_msg = "PROBLEMS DETECTED!\n\n" + "\n\n".join(problems)
             # Prepend with [ERROR] so that it gets colored in the GitHub output


### PR DESCRIPTION
Update `tcod` index meta-database:
- Use `tcod` ID instead of `cod`

Clarify details in README.

Re-add repo top-level symlink to `providers.json`.
Since this is referenced in READMEs, it would be good to have the file existing.

Note, this PR originally sprang from the idea of adding `meta` in the response, however, I found that this is indeed not necessary from the spec ("at least one of the top-level fields has to be present, `data` being one of them", so it's all good).
However, there were still some minor changes that could be done that I found, so the PR exists :)