### PR TITLE
Update providers database to OPTIMADE v1.0.0 format

### DIFF
--- a/src/index-metadbs/cod/v1/info.json
+++ b/src/index-metadbs/cod/v1/info.json
@@ -1,9 +1,17 @@
 {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
    "data" : {
       "attributes" : {
          "available_api_versions" : [
             {
-               "version" : "1.0.0-rc.2",
+               "version" : "1.0.0",
                "url" : "http://providers.optimade.org/index-metadbs/cod/v1/"
             }
          ],
@@ -18,7 +26,7 @@
             "info",
             "links"
          ],
-         "api_version" : "1.0.0-rc.2"
+         "api_version" : "1.0.0"
       },
       "type" : "info",
       "relationships" : {

--- a/src/index-metadbs/cod/v1/info.json
+++ b/src/index-metadbs/cod/v1/info.json
@@ -5,7 +5,7 @@
            "representation" : "/info"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data" : {
       "attributes" : {

--- a/src/index-metadbs/cod/v1/links.json
+++ b/src/index-metadbs/cod/v1/links.json
@@ -1,4 +1,12 @@
 {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
    "data" : [
       {
          "id" : "cod",

--- a/src/index-metadbs/cod/v1/links.json
+++ b/src/index-metadbs/cod/v1/links.json
@@ -5,7 +5,7 @@
            "representation" : "/links"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data" : [
       {

--- a/src/index-metadbs/exmpl/v1/info.json
+++ b/src/index-metadbs/exmpl/v1/info.json
@@ -1,9 +1,17 @@
 {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
    "data" : {
       "attributes" : {
          "available_api_versions" : [
             {
-               "version" : "1.0.0-rc.2",
+               "version" : "1.0.0",
                "url" : "http://providers.optimade.org/index-metadbs/exmpl/v1/"
             }
          ],
@@ -18,7 +26,7 @@
             "info",
             "links"
          ],
-         "api_version" : "1.0.0-rc.2"
+         "api_version" : "1.0.0"
       },
       "type" : "info",
       "relationships" : {

--- a/src/index-metadbs/exmpl/v1/info.json
+++ b/src/index-metadbs/exmpl/v1/info.json
@@ -5,7 +5,7 @@
            "representation" : "/info"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data" : {
       "attributes" : {

--- a/src/index-metadbs/exmpl/v1/links.json
+++ b/src/index-metadbs/exmpl/v1/links.json
@@ -5,7 +5,7 @@
            "representation" : "/links"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data" : [
       {

--- a/src/index-metadbs/exmpl/v1/links.json
+++ b/src/index-metadbs/exmpl/v1/links.json
@@ -1,4 +1,12 @@
 {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
    "data" : [
       {
          "id" : "exmpl",

--- a/src/index-metadbs/tcod/v1/info.json
+++ b/src/index-metadbs/tcod/v1/info.json
@@ -1,9 +1,17 @@
 {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
    "data" : {
       "attributes" : {
          "available_api_versions" : [
             {
-               "version" : "1.0.0-rc.2",
+               "version" : "1.0.0",
                "url" : "http://providers.optimade.org/index-metadbs/tcod/v1/"
             }
          ],
@@ -18,7 +26,7 @@
             "info",
             "links"
          ],
-         "api_version" : "1.0.0-rc.2"
+         "api_version" : "1.0.0"
       },
       "type" : "info",
       "relationships" : {

--- a/src/index-metadbs/tcod/v1/info.json
+++ b/src/index-metadbs/tcod/v1/info.json
@@ -5,7 +5,7 @@
            "representation" : "/info"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data" : {
       "attributes" : {

--- a/src/index-metadbs/tcod/v1/links.json
+++ b/src/index-metadbs/tcod/v1/links.json
@@ -1,4 +1,12 @@
 {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
    "data" : [
       {
          "id" : "tcod",

--- a/src/index-metadbs/tcod/v1/links.json
+++ b/src/index-metadbs/tcod/v1/links.json
@@ -5,7 +5,7 @@
            "representation" : "/links"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data" : [
       {

--- a/src/info/v1/info.json
+++ b/src/info/v1/info.json
@@ -1,14 +1,22 @@
 {
-  "data": {
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data": {
     "type": "info",
     "id": "/",
     "relationships": {},
     "attributes": {
-      "api_version": "1.0.0-rc.2",
+      "api_version": "1.0.0",
       "available_api_versions": [
         {
           "url": "https://www.optimade.org/providers/optimade/v1/",
-          "version": "1.0.0-rc.2"
+          "version": "1.0.0"
         }
       ],
       "formats": [

--- a/src/info/v1/info.json
+++ b/src/info/v1/info.json
@@ -5,7 +5,7 @@
            "representation" : "/info"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data": {
     "type": "info",

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -5,7 +5,7 @@
            "representation" : "/links"
        },
        "more_data_available" : false,
-       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
    },
    "data": [
     {

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -1,5 +1,13 @@
 {
-  "data": [
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https:/schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data": [
     {
       "type": "links",
       "id": "aiida",


### PR DESCRIPTION
Note: this makes a schema reference to https://schemas.optimade.org/openapi/v1/optimade_index.html in the schemas repo. So we probably shouldn't merge this until that subdomain has been created.

Oh, and it won't validate until the validator is updated for OPTIMADE v1.0.0

Edit (Casper): The schema reference is https://schemas.optimade.org/openapi/v1.0/optimade_index.json and it's up, good to go :)
Also, closes #41.