### PR TITLE
Update links to the online specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The list of providers is published as an [OPTIMADE](https://www.optimade.org/) Index Meta-Database here: [https://providers.optimade.org/](https://providers.optimade.org/)
 
-You can obtain the list of providers in a machine-readable format following the [OPTIMADE specification for Index Meta-Databases](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst#32index-meta-database) by using the following URL:
+You can obtain the list of providers in a machine-readable format following the [OPTIMADE specification for Index Meta-Databases](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#index-meta-database) by using the following URL:
 
 - [https://providers.optimade.org/v1/links](https://providers.optimade.org/v1/links)
 
@@ -43,7 +43,7 @@ Hence, to update the list of providers, file a pull-request against the reposito
 
 ## Requirements to be listed in this providers list
 
-It is a policy of this providers list ([providers.optimade.org](http://providers.optimade.org)) that links inside `providers.json` must be links to an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst#32index-meta-database).
+It is a policy of this providers list ([providers.optimade.org](http://providers.optimade.org)) that links inside `providers.json` must be links to an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#index-meta-database).
 
 If you only have one or few databases in your implementation, and you do not want to host an Index Meta-Database yourself, you can host the Index Meta-Database directly in this repository.
 You can find instructions [here](./src/index-metadbs).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The list of providers is published as an [OPTIMADE](https://www.optimade.org/) Index Meta-Database here: [https://providers.optimade.org/](https://providers.optimade.org/)
 
-You can obtain the list of providers in a machine-readable format following the [OPTIMADE specification for Index Meta-Databases](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#index-meta-database) by using the following URL:
+You can obtain the list of providers in a machine-readable format following the [OPTIMADE specification for Index Meta-Databases](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#index-meta-database) by using the following URL:
 
 - [https://providers.optimade.org/v1/links](https://providers.optimade.org/v1/links)
 
@@ -43,7 +43,7 @@ Hence, to update the list of providers, file a pull-request against the reposito
 
 ## Requirements to be listed in this providers list
 
-It is a policy of this providers list ([providers.optimade.org](http://providers.optimade.org)) that links inside `providers.json` must be links to an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#index-meta-database).
+It is a policy of this providers list ([providers.optimade.org](http://providers.optimade.org)) that links inside `providers.json` must be links to an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#index-meta-database).
 
 If you only have one or few databases in your implementation, and you do not want to host an Index Meta-Database yourself, you can host the Index Meta-Database directly in this repository.
 You can find instructions [here](./src/index-metadbs).

--- a/src/index-metadbs/README.md
+++ b/src/index-metadbs/README.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This folder hosts static versions of Index Meta-Databases for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#index-meta-database) themselves.
+This folder hosts static versions of Index Meta-Databases for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#index-meta-database) themselves.
 
 Note: while providing an Index Meta-Database is not required by the OPTIMADE API specification, it is instead required in order to be listed in this List of Providers ([providers.optimade.org](http://providers.optimade.org)).
 
@@ -28,14 +28,14 @@ Note that "changes" here refer solely to changes to the *list of sub-databases*;
    - change the attributes `name`, `description` and `homepage` to contain the correct content.
      Please reuse the *same* content as the one you specified in the main `providers.json` file.
    - point the `base_url` to the base URL of your OPTIMADE implementation.
-     Note, this should be the un-versioned base URL (see [the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#base-url) for more information on this).
+     Note, this should be the un-versioned base URL (see [the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#base-url) for more information on this).
 
 3. Adapt the content of the `info.json` file.
    In particular, you should change two fields:
 
    - change the URL of the `available_api_versions` by replacing `exmpl` with your identifier: `http://providers.optimade.org/index-metadbs/exmpl2/v1/`.
    - change the `id` inside `data -> relationships -> default -> data -> id` from `exmpl` to the correct ID from the list of links in the `links.json` file.
-     As [explained in the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#base-info-endpoint), this should be the ID of the database that should be considered as the "default" sub-database by clients.
+     As [explained in the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#base-info-endpoint), this should be the ID of the database that should be considered as the "default" sub-database by clients.
 
      If you only have one sub-database and you followed the instructions above, you should use here your provider identifier.
      If you do not wish to have a default database, set the `relationships` value to an empty dictionary or set the value of `relationships -> default -> data` to `null`.

--- a/src/index-metadbs/README.md
+++ b/src/index-metadbs/README.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This folder hosts static versions of Index Meta-Databases for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/develop/optimade.rst#32index-meta-database) themselves.
+This folder hosts static versions of Index Meta-Databases for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#index-meta-database) themselves.
 
 Note: while providing an Index Meta-Database is not required by the OPTIMADE API specification, it is instead required in order to be listed in this List of Providers ([providers.optimade.org](http://providers.optimade.org)).
 
@@ -28,14 +28,14 @@ Note that "changes" here refer solely to changes to the *list of sub-databases*;
    - change the attributes `name`, `description` and `homepage` to contain the correct content.
      Please reuse the *same* content as the one you specified in the main `providers.json` file.
    - point the `base_url` to the base URL of your OPTIMADE implementation.
-     Note, this should be the un-versioned base URL (see [the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#base-url) for more information on this).
+     Note, this should be the un-versioned base URL (see [the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#base-url) for more information on this).
 
 3. Adapt the content of the `info.json` file.
    In particular, you should change two fields:
 
    - change the URL of the `available_api_versions` by replacing `exmpl` with your identifier: `http://providers.optimade.org/index-metadbs/exmpl2/v1/`.
    - change the `id` inside `data -> relationships -> default -> data -> id` from `exmpl` to the correct ID from the list of links in the `links.json` file.
-     As [explained in the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTiMaDe/blob/develop/optimade.rst#base-info-endpoint), this should be the ID of the database that should be considered as the "default" sub-database by clients.
+     As [explained in the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/v1.0.0/optimade.rst#base-info-endpoint), this should be the ID of the database that should be considered as the "default" sub-database by clients.
 
      If you only have one sub-database and you followed the instructions above, you should use here your provider identifier.
      If you do not wish to have a default database, set the `relationships` value to an empty dictionary or set the value of `relationships -> default -> data` to `null`.


### PR DESCRIPTION
Closes #38.

Use `v1.0.0` instead of `develop`.
Use un-numbered link anchors.
Use the new repository name `OPTIMADE` instead of `OPTiMaDe`.