### PR TITLE
Adding OQMD's info to providers.json

### DIFF
--- a/src/index-metadbs/oqmd/v1/info.json
+++ b/src/index-metadbs/oqmd/v1/info.json
@@ -1,0 +1,43 @@
+{
+    "meta" : {
+        "api_version" : "1.0.0",
+        "query" : {
+            "representation" : "/info"
+        },
+        "more_data_available" : false,
+        "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+    },
+    "data" : {
+       "attributes" : {
+          "available_api_versions" : [
+             {
+                "version" : "1.0.0",
+                "url" : "http://providers.optimade.org/index-metadbs/oqmd/v1/"
+             }
+          ],
+          "is_index" : true,
+          "formats" : [
+             "json"
+          ],
+          "entry_types_by_format" : {
+             "json" : []
+          },
+          "available_endpoints" : [
+             "info",
+             "links"
+          ],
+          "api_version" : "1.0.0"
+       },
+       "type" : "info",
+       "relationships" : {
+          "default" : {
+             "data" : {
+                "id" : "oqmd",
+                "type" : "links"
+             }
+          }
+       },
+       "id" : "/"
+    }
+ }
+ 

--- a/src/index-metadbs/oqmd/v1/links.json
+++ b/src/index-metadbs/oqmd/v1/links.json
@@ -1,0 +1,34 @@
+{
+    "meta": {
+        "api_version": "1.0.0",
+        "query": {
+            "representation": "/links"
+        },
+        "more_data_available": false,
+        "schema": "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+    },
+    "data": [
+        {
+            "id": "oqmd",
+            "type": "links",
+            "attributes": {
+                "name": "The OQMD",
+                "description": "The Open Quantum Materials Database endpoint",
+                "base_url": "http://oqmd.org/optimade/",
+                "homepage": "http://oqmd.org",
+                "link_type": "child"
+            }
+        },
+        {
+            "id": "optimade-providers",
+            "type": "links",
+            "attributes": {
+                "name": "OPTIMADE Providers Index Meta-Database",
+                "description": "The list of OPTIMADE providers maintained by Materials-Consortia",
+                "base_url": "https://providers.optimade.org",
+                "homepage": "https://www.optimade.org",
+                "link_type": "providers"
+            }
+        }
+    ]
+}

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -144,9 +144,9 @@
       "type": "links",
       "id": "oqmd",
       "attributes": {
-        "name": "The Open Quantum Materials Database",
+        "name": "The Open Quantum Materials Database (OQMD)",
         "description": "The OQMD is a database of DFT calculated thermodynamic and structural properties of materials",
-        "base_url": "http://oqmd.org/optimade",
+        "base_url": "http://providers.optimade.org/index-metadbs/oqmd",
         "homepage": "http://oqmd.org",
         "link_type": "external"
       }

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -144,10 +144,10 @@
       "type": "links",
       "id": "oqmd",
       "attributes": {
-        "name": "open quantum materials database",
-        "description": "",
-        "base_url": null,
-        "homepage": null,
+        "name": "The Open Quantum Materials Database",
+        "description": "The OQMD is a database of DFT calculated thermodynamic and structural properties of materials",
+        "base_url": "http://oqmd.org/optimade",
+        "homepage": "http://oqmd.org",
         "link_type": "external"
       }
     },


### PR DESCRIPTION
OPTiMaDe v1.0.0 is now fully incorporated into `qmpy` (Django-based Python API that OQMD is based on). 
I can pull the new scripts onto the public `oqmd.org` website once the internal review of `qmpy` is finished, but the final base-URLs are now designated.

I will update it here when the `optimade-validator` can access `oqmd.org/optimade` for validation. Created this PR now to initiate the process.
