### PR TITLE
Update information for omdb in providers.json

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -122,10 +122,10 @@
       "type": "links",
       "id": "omdb",
       "attributes": {
-        "name": "open materials database",
-        "description": "",
-        "base_url": null,
-        "homepage": null,
+        "name": "Open Materials Database",
+        "description": "The Open Materials Database (omdb) is a database of materials properties maintained by the developers of the High-Throughput Toolkit (httk) to enable easy programmatic interaction with this toolkit",
+        "base_url": "https://optimade-index.openmaterialsdb.se",
+        "homepage": "http://openmaterialsdb.se",
         "link_type": "external"
       }
     },

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -123,7 +123,7 @@
       "id": "omdb",
       "attributes": {
         "name": "Open Materials Database",
-        "description": "The Open Materials Database (omdb) is a database of materials properties maintained by the developers of the High-Throughput Toolkit (httk) to enable easy programmatic interaction with this toolkit",
+        "description": "The Open Materials Database (omdb) is a database of materials properties maintained by the developers of the High-Throughput Toolkit (httk). It enables easy access to useful materials data, in particular via programmatic interaction using this toolkit.",
         "base_url": "https://optimade-index.openmaterialsdb.se",
         "homepage": "http://openmaterialsdb.se",
         "link_type": "external"


### PR DESCRIPTION
Now httk has support for hosting OPTIMADE v1.0.0, which we are setting up for hosting omdb. This PR updates the omdb info accordingly to point to our index meta-database.