### PR TITLE
Add support for /versions endpoint

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -5,6 +5,7 @@
 # Returning 200 just returns the content without doing a HTTP redirect, i.e.
 # without changing the URL, that is what we want to achieve here
 # https://docs.netlify.com/routing/redirects/redirect-options/#http-status-codes
+/versions	/src/versions.csv	200!
 /providers.json	/src/links/v1/providers.json	200!
 /v1/links	/src/links/v1/providers.json	200!
 /v1/info	/src/info/v1/info.json	200!

--- a/src/versions.csv
+++ b/src/versions.csv
@@ -1,0 +1,2 @@
+version
+1


### PR DESCRIPTION
The index meta-database isn't exempt from the mandatory /versions endpoint in the OPTIMADE specification v1.0.0 section 5.2 (right?). 

This PR adds this support when hosing via netlify.