### PR TITLE
Add AFLOW to providers lists

### DIFF
--- a/src/index-metadbs/aflow/v1/info.json
+++ b/src/index-metadbs/aflow/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/aflow/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/aflow/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/aflow/v1/info.json
+++ b/src/index-metadbs/aflow/v1/info.json
@@ -1,0 +1,42 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : {
+      "attributes" : {
+         "available_api_versions" : [
+            {
+               "version" : "1.0.0",
+               "url" : "http://providers.optimade.org/index-metadbs/aflow/v1/"
+            }
+         ],
+         "is_index" : true,
+         "formats" : [
+            "json"
+         ],
+         "entry_types_by_format" : {
+            "json" : []
+         },
+         "available_endpoints" : [
+            "info",
+            "links"
+         ],
+         "api_version" : "1.0.0"
+      },
+      "type" : "info",
+      "relationships" : {
+         "default" : {
+            "data" : {
+               "id" : "aflow",
+               "type" : "links"
+            }
+         }
+      },
+      "id" : "/"
+   }
+}

--- a/src/index-metadbs/aflow/v1/links.json
+++ b/src/index-metadbs/aflow/v1/links.json
@@ -1,0 +1,34 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : [
+      {
+         "id" : "aflow",
+         "type" : "links",
+         "attributes" : {
+            "name": "AFLOW",
+            "description": "The AFLOW OPTIMADE endpoint",
+            "base_url": "http://aflow.org/API/optimade/",
+            "homepage": "https://aflow.org",
+            "link_type": "child"
+         }
+      },
+      {
+         "id" : "optimade-providers",
+         "type" : "links",
+         "attributes" : {
+            "name": "OPTIMADE Providers Index Meta-Database",
+            "description": "The list of OPTIMADE providers maintained by Materials-Consortia",
+            "base_url": "https://providers.optimade.org",
+            "homepage": "https://www.optimade.org",
+            "link_type": "providers"
+         }
+      }
+   ]
+}

--- a/src/index-metadbs/aflow/v1/links.json
+++ b/src/index-metadbs/aflow/v1/links.json
@@ -15,7 +15,7 @@
             "name": "AFLOW",
             "description": "The AFLOW OPTIMADE endpoint",
             "base_url": "http://aflow.org/API/optimade/",
-            "homepage": "https://aflow.org",
+            "homepage": "http://aflow.org",
             "link_type": "child"
          }
       },

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -24,9 +24,9 @@
       "id": "aflow",
       "attributes": {
         "name": "AFLOW",
-        "description": "",
-        "base_url": "http://providers.optimade.org/index-metadbs/aflow",
-        "homepage": "https://aflow.org",
+        "description": "Automatic FLOW (AFLOW) database for computational materials science",
+        "base_url": "https://providers.optimade.org/index-metadbs/aflow",
+        "homepage": "http://aflow.org",
         "link_type": "external"
       }
     },

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -23,10 +23,10 @@
       "type": "links",
       "id": "aflow",
       "attributes": {
-        "name": "aflow.org",
+        "name": "AFLOW",
         "description": "",
-        "base_url": null,
-        "homepage": null,
+        "base_url": "http://providers.optimade.org/index-metadbs/aflow",
+        "homepage": "https://aflow.org",
         "link_type": "external"
       }
     },


### PR DESCRIPTION
Adds the directory providers/src/index-metadbs/aflow with info.json and links.json files. Also modifies the providers.json file in accordance with the instructions in the README.