### PR TITLE
Fix name values for matcloud

### DIFF
--- a/src/index-metadbs/matcloud/v1/links.json
+++ b/src/index-metadbs/matcloud/v1/links.json
@@ -12,8 +12,8 @@
          "id" : "matcloud",
          "type" : "links",
          "attributes" : {
-            "name": "An integrated high-throughput computational materials platform",
-            "description": "MatCloud is a high-throughput computing platform integrating data, simulation and supercomputing.",
+            "name": "MatCloud",
+            "description": "A high-throughput computing platform integrating data, simulation and supercomputing.",
             "base_url": null,
             "homepage": "http://matcloud.cnic.cn",
             "link_type": "child"

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -67,8 +67,8 @@
       "type": "links",
       "id": "matcloud",
       "attributes": {
-        "name": "An integrated high-throughput computational materials platform",
-        "description": "MatCloud is a high-throughput computing platform integrating data, simulation and supercomputing.",
+        "name": "MatCloud",
+        "description": "A high-throughput computing platform integrating data, simulation and supercomputing.",
         "base_url": "https://providers.optimade.org/index-metadbs/matcloud",
         "homepage": "http://matcloud.cnic.cn",
         "link_type": "external"


### PR DESCRIPTION
Fixes #64.

The `name` value should be a title.
I removed the first part of the `description` value to not be redundant.