### PR TITLE
Add MPDS provider

### DIFF
--- a/src/index-metadbs/mpds/v1/info.json
+++ b/src/index-metadbs/mpds/v1/info.json
@@ -1,0 +1,42 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : {
+      "attributes" : {
+         "available_api_versions" : [
+            {
+               "version" : "1.0.0",
+               "url" : "https://providers.optimade.org/index-metadbs/mpds/v1/"
+            }
+         ],
+         "is_index" : true,
+         "formats" : [
+            "json"
+         ],
+         "entry_types_by_format" : {
+            "json" : []
+         },
+         "available_endpoints" : [
+            "info",
+            "links"
+         ],
+         "api_version" : "1.0.0"
+      },
+      "type" : "info",
+      "relationships" : {
+         "default" : {
+            "data" : {
+               "id" : "mpds",
+               "type" : "links"
+            }
+         }
+      },
+      "id" : "/"
+   }
+}

--- a/src/index-metadbs/mpds/v1/links.json
+++ b/src/index-metadbs/mpds/v1/links.json
@@ -1,0 +1,34 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : [
+      {
+         "id" : "mpds",
+         "type" : "links",
+         "attributes" : {
+            "name": "Materials Platform for Data Science",
+            "description": "A highly curated Pauling File dataset based on ~0.5M publications and backing up Springer Materials, ICDD PDF, ASM APD, MedeA, Pearson Crystal Data, AtomWork Advanced, etc.",
+            "base_url": "https://api.mpds.io",
+            "homepage": "https://mpds.io",
+            "link_type": "child"
+         }
+      },
+      {
+         "id" : "optimade-providers",
+         "type" : "links",
+         "attributes" : {
+            "name": "OPTIMADE Providers Index Meta-Database",
+            "description": "The list of OPTIMADE providers maintained by Materials-Consortia",
+            "base_url": "https://providers.optimade.org",
+            "homepage": "https://www.optimade.org",
+            "link_type": "providers"
+         }
+      }
+   ]
+}

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -100,10 +100,10 @@
       "type": "links",
       "id": "mpds",
       "attributes": {
-        "name": "materials platform for data science",
-        "description": "",
-        "base_url": null,
-        "homepage": null,
+        "name": "Materials Platform for Data Science",
+        "description": "A highly curated Pauling File dataset based on ~0.5M publications and backing up Springer Materials, ICDD PDF, ASM APD, MedeA, Pearson Crystal Data, AtomWork Advanced, etc.",
+        "base_url": "https://providers.optimade.org/index-metadbs/mpds",
+        "homepage": "https://mpds.io",
         "link_type": "external"
       }
     },


### PR DESCRIPTION
This is to introduce the Optimade support for the MPDS.

All our data of all the types are visible.

The known limitations include:

- many omitted fields in the data due to the copyright reasons
- incomplete filtering language support (_e.g._ we miss `ANY`, please, run successive requests one by one)
- still a lot of the remnants and links to the [old MPDS API](https://mpds.io/developer)