### PR TITLE
Add NecrOPTIMADE provider

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -109,6 +109,17 @@
     },
     {
       "type": "links",
+      "id": "necro",
+      "attributes": {
+        "name": "NecrOPTIMADE",
+        "description": "A provider of ephemeral OPTIMADE APIs for static or archived data.",
+        "base_url": "https://necroptimade.herokuapp.com",
+        "homepage": "https://github.com/ml-evs/necroptimade",
+        "link_type": "external"
+      }
+    },
+    {
+      "type": "links",
       "id": "nmd",
       "attributes": {
         "name": "novel materials discovery (NOMAD)",


### PR DESCRIPTION
This PR adds a provider for the WIP NecrOPTIMADE service, currently hosted on Heroku.

The index meta-database is dynamic and currently only contains a single implementation if it has been requested at the `extensions/spawn` endpoint since the last deployment. Some more notes can be found at [ml-evs/necroptimade](https://github.com/ml-evs/necroptimade).