### PR TITLE
Add details and static index meta-db for JARVIS

### DIFF
--- a/src/index-metadbs/jarvis/v1/info.json
+++ b/src/index-metadbs/jarvis/v1/info.json
@@ -1,0 +1,42 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : {
+      "attributes" : {
+         "available_api_versions" : [
+            {
+               "version" : "1.0.0",
+               "url" : "http://providers.optimade.org/index-metadbs/jarvis/v1/"
+            }
+         ],
+         "is_index" : true,
+         "formats" : [
+            "json"
+         ],
+         "entry_types_by_format" : {
+            "json" : []
+         },
+         "available_endpoints" : [
+            "info",
+            "links"
+         ],
+         "api_version" : "1.0.0"
+      },
+      "type" : "info",
+      "relationships" : {
+         "default" : {
+            "data" : {
+               "id" : "jarvis",
+               "type" : "links"
+            }
+         }
+      },
+      "id" : "/"
+   }
+}

--- a/src/index-metadbs/jarvis/v1/links.json
+++ b/src/index-metadbs/jarvis/v1/links.json
@@ -1,0 +1,34 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : [
+      {
+         "id" : "jarvis",
+         "type" : "links",
+         "attributes" : {
+            "name": "JARVIS-DFT",
+            "description": "JARVIS-DFT is a materials property repository focused on density functional theory (DFT) predictions of material properties, especially for crystalline materials.",
+            "base_url": "https://jarvis.nist.gov/optimade/jarvisdft",
+            "homepage": "https://jarvis.nist.gov",
+            "link_type": "child"
+         }
+      },
+      {
+         "id" : "optimade-providers",
+         "type" : "links",
+         "attributes" : {
+            "name": "OPTIMADE Providers Index Meta-Database",
+            "description": "The list of OPTIMADE providers maintained by Materials-Consortia",
+            "base_url": "https://providers.optimade.org",
+            "homepage": "https://www.optimade.org",
+            "link_type": "providers"
+         }
+      }
+   ]
+}

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -179,7 +179,7 @@
       "attributes": {
         "name": "Joint Automated Repository for Various Integrated Simulations (JARVIS)",
         "description": "JARVIS is a repository designed to automate materials discovery using classical force-field, density functional theory, machine learning calculations and experiments.",
-        "base_url": null,
+        "base_url": "http://providers.optimade.org/index-metadbs/jarvis",
         "homepage": "https://jarvis.nist.gov",
         "link_type": "external"
       }


### PR DESCRIPTION
This PR adds a static index meta-db for JARVIS and links out to the JARVIS-DFT database, which is now publicly available via OPTIMADE.

@knc6: I took the description from your website at https://www.nist.gov/programs-projects/jarvis-dft, please let me know if you want it to say something different.