### PR TITLE
Redirect static base URLs to a helpful landing page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -14,3 +14,5 @@
 /index-metadbs/:providerid/versions /src/versions.csv 200!
 /index-metadbs/:providerid/:version/links /src/index-metadbs/:providerid/:version/links.json 200!
 /index-metadbs/:providerid/:version/info /src/index-metadbs/:providerid/:version/info.json 200!
+
+/index-metadbs/:providerid /src/index-metadbs/:providerid/:version/links.json 301!

--- a/_redirects
+++ b/_redirects
@@ -15,4 +15,4 @@
 /index-metadbs/:providerid/:version/links /src/index-metadbs/:providerid/:version/links.json 200!
 /index-metadbs/:providerid/:version/info /src/index-metadbs/:providerid/:version/info.json 200!
 
-/index-metadbs/:providerid /src/index-metadbs/:providerid/v1/links.json 301!
+/index-metadbs/:providerid /src/landing_page.html 200!

--- a/_redirects
+++ b/_redirects
@@ -15,4 +15,4 @@
 /index-metadbs/:providerid/:version/links /src/index-metadbs/:providerid/:version/links.json 200!
 /index-metadbs/:providerid/:version/info /src/index-metadbs/:providerid/:version/info.json 200!
 
-/index-metadbs/:providerid /src/index-metadbs/:providerid/:version/links.json 301!
+/index-metadbs/:providerid /src/index-metadbs/:providerid/v1/links.json 301!

--- a/_redirects
+++ b/_redirects
@@ -15,4 +15,6 @@
 /index-metadbs/:providerid/:version/links /src/index-metadbs/:providerid/:version/links.json 200!
 /index-metadbs/:providerid/:version/info /src/index-metadbs/:providerid/:version/info.json 200!
 
+# Redirect bare/versioned base URLs to a helpful landing page
 /index-metadbs/:providerid /src/landing_page.html 200!
+/index-metadbs/:providerid/v1/ /src/landing_page.html 200!

--- a/src/landing_page.html
+++ b/src/landing_page.html
@@ -12,11 +12,6 @@
         h4, p { margin-left: 2em; }
         span.version {background-color: lightgrey; font-weight: bold; font-family: monospace; padding: 0em 0.5em 0em 0.5em; border-radius: 1em;}
     </style>
-    <script id="data" type="application/json">
-        {
-            "message": "This is the base URL of an OPTIMADE index meta-database, served statically from https://github.com/Materials-Consortia/providers. This URL can be appended with '/v1/info/' or '/v1/links/' to access the provider data."
-        }
-    </script>
     </head>
     <body>
         <img id="logo" width="100" src="https://avatars0.githubusercontent.com/u/23107754?s=400&u=e1580af496ac195a3ac4c445a66a5699efb0c3d3"></img>

--- a/src/landing_page.html
+++ b/src/landing_page.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>OPTIMADE Index Meta-databse</title>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="keywords" content="optimade,materials,crystals,database">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+        <link rel="shortcut icon" type="image/x-icon" href="https://www.optimade.org/optimade-python-tools/images/favicon.png">
+    <style>
+        html { margin: 2em; }
+        h4, p { margin-left: 2em; }
+        span.version {background-color: lightgrey; font-weight: bold; font-family: monospace; padding: 0em 0.5em 0em 0.5em; border-radius: 1em;}
+    </style>
+    <script id="data" type="application/json">
+        {
+            "message": "This is the base URL of an OPTIMADE index meta-database, served statically from https://github.com/Materials-Consortia/providers. This URL can be appended with '/v1/info/' or '/v1/links/' to access the provider data."
+        }
+    </script>
+    </head>
+    <body>
+        <img id="logo" width="100" src="https://avatars0.githubusercontent.com/u/23107754?s=400&u=e1580af496ac195a3ac4c445a66a5699efb0c3d3"></img>
+        <h3>This is the base URL of an <a href="https://www.optimade.org">OPTIMADE</a> index meta-database, served statically from <i class="fa fa-github"></i> <a href="https://github.com/Materials-Consortia/providers">Materials-Consortia/providers</a> on GitHub.</h3>
+        <h4>Two endpoints can be appended to the current URL: </h4>
+        <ul>
+            <li><span class="version">/v1/info/</span>, which serves information about this provider.</li>
+            <li><span class="version">/v1/links/</span>, which serves links to the databases served by this provider.</li>
+        </ul>
+    </body>
+</html>

--- a/src/landing_page.html
+++ b/src/landing_page.html
@@ -16,7 +16,7 @@
     <body>
         <img id="logo" width="100" src="https://avatars0.githubusercontent.com/u/23107754?s=400&u=e1580af496ac195a3ac4c445a66a5699efb0c3d3"></img>
         <h3>This is the base URL of an <a href="https://www.optimade.org">OPTIMADE</a> index meta-database, served statically from <i class="fa fa-github"></i> <a href="https://github.com/Materials-Consortia/providers">Materials-Consortia/providers</a> on GitHub.</h3>
-        <h4>Two endpoints can be appended to the current URL: </h4>
+        <h4>Two endpoints can be appended to the current URL (<span class="version">/v1/</span> can be omitted if already present in the URL): </h4>
         <ul>
             <li><span class="version">/v1/info/</span>, which serves information about this provider.</li>
             <li><span class="version">/v1/links/</span>, which serves links to the databases served by this provider.</li>


### PR DESCRIPTION
This PR is a potential solution for #76, by redirecting the static base URLs served here to a semi-informative landing page, rather than 404'ing.

Unfortunately netlify can't do redirects based on `Accept` headers, so serving a JSON response is not possible (unless we get rid of this HTML response). The HTML response mimics the way most providers are handling their base URLs, so I don't think there is an issue here.