### PR TITLE
Switch off aggregation for JARVIS until filtering/pagination are implemented

### DIFF
--- a/src/index-metadbs/jarvis/v1/links.json
+++ b/src/index-metadbs/jarvis/v1/links.json
@@ -16,7 +16,8 @@
             "description": "JARVIS-DFT is a materials property repository focused on density functional theory (DFT) predictions of material properties, especially for crystalline materials.",
             "base_url": "https://jarvis.nist.gov/optimade/jarvisdft",
             "homepage": "https://jarvis.nist.gov",
-            "link_type": "child"
+            "link_type": "child",
+            "aggregate": "staging"
          }
       },
       {


### PR DESCRIPTION
Pinging @knc6, I think this is a good idea as it will stop the multi-provider OPTIMADE clients from downloading all of JARVIS every time they query with a filter.