### PR TITLE
Error handling for index meta-databases that are down

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -150,7 +150,7 @@ class ProvidersValidator(unittest.TestCase):
                                     response_content = query_optimade(info_endpoint)
                             else:
                                 raise
-                    except urllib.error.HTTPError as exc:
+                    except urllib.error.URLError as exc:
                         fallback_string = (
                             ""
                             if len(tested_info_endpoints) == 1


### PR DESCRIPTION
My index meta-database is currently down due to a forced migration. This should not cause the tests here to fail.

We are currently catching `urllib.errors.HTTPError`, yet a timeout on a down database actually raises a `urllib.errors.URLError` (which `HTTPError` inherits from).

This PR simply catches `URLError` instead