### PR TITLE
Use Python 3.10 in CI and bump GH actions

### DIFF
--- a/.github/workflows/python_validate.yml
+++ b/.github/workflows/python_validate.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install OPTIMADE
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python_validate.yml
+++ b/.github/workflows/python_validate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.10
     - name: Install OPTIMADE

--- a/.github/workflows/python_validate.yml
+++ b/.github/workflows/python_validate.yml
@@ -8,7 +8,7 @@ jobs:
     name: Sanity checks (pytest)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/python_validate.yml
+++ b/.github/workflows/python_validate.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install OPTIMADE
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
As we are dropping support for python 3.7 in the optimade python tools, I think we should drop it here too.