### PR TITLE
Remove necroptimade base URL

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -124,7 +124,7 @@
       "attributes": {
         "name": "NecrOPTIMADE",
         "description": "A provider of ephemeral OPTIMADE APIs for static or archived data.",
-        "base_url": "https://necroptimade.herokuapp.com",
+        "base_url": null,
         "homepage": "https://github.com/ml-evs/necroptimade",
         "link_type": "external"
       }


### PR DESCRIPTION
This PR simply sets the necroptimade base URL to null, as I have not had time to redeploy it away from heroku (and may never).