### PR TITLE
Add CMR provider

### DIFF
--- a/src/index-metadbs/cmr/v1/info.json
+++ b/src/index-metadbs/cmr/v1/info.json
@@ -1,0 +1,42 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/info"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : {
+      "attributes" : {
+         "available_api_versions" : [
+            {
+               "version" : "1.0.0",
+               "url" : "http://providers.optimade.org/index-metadbs/cmr/v1/"
+            }
+         ],
+         "is_index" : true,
+         "formats" : [
+            "json"
+         ],
+         "entry_types_by_format" : {
+            "json" : []
+         },
+         "available_endpoints" : [
+            "info",
+            "links"
+         ],
+         "api_version" : "1.0.0"
+      },
+      "type" : "info",
+      "relationships" : {
+         "default" : {
+            "data" : {
+               "id" : "cmr",
+               "type" : "links"
+            }
+         }
+      },
+      "id" : "/"
+   }
+}

--- a/src/index-metadbs/cmr/v1/links.json
+++ b/src/index-metadbs/cmr/v1/links.json
@@ -1,0 +1,34 @@
+{
+   "meta" : {
+       "api_version" : "1.0.0",
+       "query" : {
+           "representation" : "/links"
+       },
+       "more_data_available" : false,
+       "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : [
+      {
+         "id" : "cmr",
+         "type" : "links",
+         "attributes" : {
+            "name": "CMR Database",
+            "description": "Computational materials repository.",
+            "base_url": "https://cmr-optimade.fysik.dtu.dk",
+            "homepage": "https://cmr.fysik.dtu.dk",
+            "link_type": "child"
+         }
+      },
+      {
+         "id" : "optimade-providers",
+         "type" : "links",
+         "attributes" : {
+            "name": "OPTIMADE Providers Index Meta-Database",
+            "description": "The list of OPTIMADE providers maintained by Materials-Consortia",
+            "base_url": "https://providers.optimade.org",
+            "homepage": "https://www.optimade.org",
+            "link_type": "providers"
+         }
+      }
+   ]
+}

--- a/src/index-metadbs/cmr/v1/links.json
+++ b/src/index-metadbs/cmr/v1/links.json
@@ -12,8 +12,8 @@
          "id" : "cmr",
          "type" : "links",
          "attributes" : {
-            "name": "CMR Database",
-            "description": "Computational materials repository.",
+             "name": "Computational materials repository (CMR)",
+             "description": "CMR is a collection of materials repositories from different projects such as C2DB, QPOD and many more",
             "base_url": "https://cmr-optimade.fysik.dtu.dk",
             "homepage": "https://cmr.fysik.dtu.dk",
             "link_type": "child"

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -58,7 +58,7 @@
       "attributes": {
         "name": "Computational materials repository (CMR)",
         "description": "CMR is a collection of materials repositories from different projects such as C2DB, QPOD and many more",
-        "base_url": "https://cmr-optimade.fysik.dtu.dk",
+        "base_url": "http://providers.optimade.org/index-metadbs/cmr",
         "homepage": "https://cmr.fysik.dtu.dk",
         "link_type": "external"
       }

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -54,6 +54,17 @@
     },
     {
       "type": "links",
+      "id": "cmr",
+      "attributes": {
+        "name": "CMR Database",
+        "description": "Computational materials repository.",
+        "base_url": "https://cmr-optimade.fysik.dtu.dk",
+        "homepage": "https://cmr.fysik.dtu.dk",
+        "link_type": "external"
+      }
+    },
+    {
+      "type": "links",
       "id": "exmpl",
       "attributes": {
         "name": "Example provider",

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -56,8 +56,8 @@
       "type": "links",
       "id": "cmr",
       "attributes": {
-        "name": "CMR Database",
-        "description": "Computational materials repository.",
+        "name": "Computational materials repository (CMR)",
+        "description": "CMR is a collection of materials repositories from different projects such as C2DB, QPOD and many more",
         "base_url": "https://cmr-optimade.fysik.dtu.dk",
         "homepage": "https://cmr.fysik.dtu.dk",
         "link_type": "external"


### PR DESCRIPTION
Adds CMR as a provider to the ASE databases in the CMR-project (https://cmr.fysik.dtu.dk/) using the ase-optimade software: https://gitlab.com/jensj/ase-optimade