### PR TITLE
Remove CCPNC base URL

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -47,7 +47,7 @@
       "attributes": {
         "name": "CCP-NC Database",
         "description": "The Collaborative Computational Project for NMR Crystallography (CCP-NC) Database hosts calculated NMR parameters submitted by users in the magres format.",
-        "base_url": "http://providers.optimade.org/index-metadbs/ccpnc",
+        "base_url": null,
         "homepage": "https://www.ccpnc.ac.uk/database",
         "link_type": "external"
       }


### PR DESCRIPTION
This PR removes the `base_url` for CCPNC-DB until their OPTIMADE API is up and
running.
