### PR TITLE
Add MPDD provider

### DIFF
--- a/src/index-metadbs/mpdd/v1/info.json
+++ b/src/index-metadbs/mpdd/v1/info.json
@@ -1,0 +1,43 @@
+{
+    "meta" : {
+        "api_version" : "1.0.0",
+        "query" : {
+            "representation" : "/info"
+        },
+        "more_data_available" : false,
+        "schema" : "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+    },
+    "data" : {
+       "attributes" : {
+          "available_api_versions" : [
+             {
+                "version" : "1.0.0",
+                "url" : "http://providers.optimade.org/index-metadbs/mpdd/v1/"
+             }
+          ],
+          "is_index" : true,
+          "formats" : [
+             "json"
+          ],
+          "entry_types_by_format" : {
+             "json" : []
+          },
+          "available_endpoints" : [
+             "info",
+             "links"
+          ],
+          "api_version" : "1.0.0"
+       },
+       "type" : "info",
+       "relationships" : {
+          "default" : {
+             "data" : {
+                "id" : "mpdd",
+                "type" : "links"
+             }
+          }
+       },
+       "id" : "/"
+    }
+ }
+ 

--- a/src/index-metadbs/mpdd/v1/links.json
+++ b/src/index-metadbs/mpdd/v1/links.json
@@ -13,7 +13,7 @@
          "type": "links",
          "attributes": {
             "name": "Material-Property-Descriptor Database",
-            "description": "Material-Property-Descriptor Database (MPDD) of atomic structures. Optimized for the high-throughput deployment of material featurizers and ML models and maintained by Phases Research Lab (phaseslab.org) at The Pennsylvania State University",
+            "description": "Material-Property-Descriptor Database (MPDD) of atomic structures. Optimized for the high-throughput deployment of material featurizers and ML models. Maintained by Phases Research Lab (phaseslab.org) at The Pennsylvania State University",
             "base_url": "http://mpddoptimade.phaseslab.org",
             "homepage": "https://phaseslab.com/mpdd",
             "link_type": "child"

--- a/src/index-metadbs/mpdd/v1/links.json
+++ b/src/index-metadbs/mpdd/v1/links.json
@@ -1,0 +1,34 @@
+{
+   "meta": {
+       "api_version": "1.0.0",
+       "query": {
+           "representation": "/links"
+       },
+       "more_data_available": false,
+       "schema": "https://schemas.optimade.org/openapi/v1.0/optimade_index.json"
+   },
+   "data" : [
+      {
+         "id": "mpdd",
+         "type": "links",
+         "attributes": {
+            "name": "Material-Property-Descriptor Database",
+            "description": "Material-Property-Descriptor Database (MPDD) of atomic structures. Optimized for the high-throughput deployment of material featurizers and ML models and maintained by Phases Research Lab (phaseslab.org) at The Pennsylvania State University",
+            "base_url": "http://mpddoptimade.phaseslab.org",
+            "homepage": "https://phaseslab.com/mpdd",
+            "link_type": "child"
+         }
+      },
+      {
+         "id" : "optimade-providers",
+         "type": "links",
+         "attributes": {
+            "name": "OPTIMADE Providers Index Meta-Database",
+            "description": "The list of OPTIMADE providers maintained by Materials-Consortia",
+            "base_url": "https://providers.optimade.org",
+            "homepage": "https://www.optimade.org",
+            "link_type": "providers"
+         }
+      }
+   ]
+}

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -134,7 +134,7 @@
       "id": "mpdd",
       "attributes": {
         "name": "Material-Property-Descriptor Database",
-        "description": "Material-Property-Descriptor Database (MPDD) of atomic structures. Optimized for high-throughput deployment of material featurizers and ML models and maintained by Phases Research Lab (phaseslab.org) at The Pennsylvania State University",
+        "description": "Material-Property-Descriptor Database (MPDD) of atomic structures. Optimized for the high-throughput deployment of material featurizers and ML models. Maintained by Phases Research Lab (phaseslab.org) at The Pennsylvania State University",
         "base_url": "https://providers.optimade.org/index-metadbs/mpdd",
         "homepage": "https://www.phaseslab.com/mpdd",
         "link_type": "external"

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -131,6 +131,17 @@
     },
     {
       "type": "links",
+      "id": "mpdd",
+      "attributes": {
+        "name": "Material-Property-Descriptor Database",
+        "description": "Material-Property-Descriptor Database (MPDD) of atomic structures. Optimized for high-throughput deployment of material featurizers and ML models and maintained by Phases Research Lab (phaseslab.org) at The Pennsylvania State University",
+        "base_url": "https://providers.optimade.org/index-metadbs/mpdd",
+        "homepage": "https://www.phaseslab.com/mpdd",
+        "link_type": "external"
+      }
+    },
+    {
+      "type": "links",
       "id": "mpds",
       "attributes": {
         "name": "Materials Platform for Data Science",


### PR DESCRIPTION
This PR adds Material-Property-Descriptor Database (MPDD) ([description](https://phaseslab.com/mpdd) / [partial access](mpdd.phaseslab.com)) and its OPTIMADE endpoint available at [mpddoptimade.phaseslab.org](http://mpddoptimade.phaseslab.org) to the list of providers. 

MPDD is a data infrastructure with around 4 million atomic structures, optimized for the high-throughput deployment of material featurizers and ML models utilizing them. While the infrastructure access is available to collaborators only, all structures in the database are made publicly available in a synchronized mirror with the data cast into the OPTIMADE-compliant schema.

The database is maintained by Prof. Zi-Kui Liu's @PhasesResearchLab ([phaseslab.org](https://phaseslab.org)) at The Pennsylvania State University.