### PR TITLE
Tidying up old links

### DIFF
--- a/.github/workflows/ci_validate.yml
+++ b/.github/workflows/ci_validate.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check deploy preview is up
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Wait a maximum of 3 min for the preview site to be up
       run: .github/workflows/wait_for_it.sh --host="${DEPLOY_PREVIEW}" --port=443 -t 180
 
@@ -36,9 +36,9 @@ jobs:
     needs:
       check_deploy_preview
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install OPTIMADE

--- a/README.md
+++ b/README.md
@@ -28,15 +28,18 @@ The OPTIMADE providers repository is hosted here: [https://github.com/Materials-
 The repository is organized this way:
 
 - `/src/links/<version>/providers.json` is the current providers.json file formatted according to OPTIMADE version `<version>` and any later version that uses a format that is backward compatible with this version.
-
-- `/src/info/<version>/info.json` is the proper response to the info endpoint formatted according to OPTIMADE version `<version>` and any later version that uses a format that is backward compatible with this version.
+  Contributors should edit this file when adding a new provider, and may also want to add an index-metadatabase (see below).
 
 - `/src/index-metadbs/<provider_name>/<version>/info.json` and `/src/index-metadbs/<provider_name>/<version>/links.json` are static Index Meta-Databases that are hosted in this repository for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain one on their own.
-  See more details and instructions in [`./src/index-metadbs/README.md`](./src/index-metadbs/README).
+  See more details and instructions in [Index Meta-Database README](./src/index-metadbs/README.md).
+
+- `/src/info/<version>/info.json` is the proper response to the info endpoint formatted according to OPTIMADE version `<version>` and any later version that uses a format that is backward compatible with this version.
+  Contributors should NOT edit this file when adding a new provider.
 
 - `/_redirects` specifies http rewrites to map index meta-database URLs `/<version>/info` and `/<version>/links` to the corresponding files under `src/`, as well as `/providers.json`.
   It also creates `/index-metadbs/<provider_name>/<version>/info.json` and `/index-metadbs/<provider_name>/<version>/links.json` URLs to point to the corresponding files in the `/src/index-metadbs` subfolders.
   This is used by the deploy tool Netlify.
+  Contributors should NOT edit files in this directory when adding a new provider.
 
 Presently, only the `v1` version of the formats exist.
 Hence, to update the list of providers, file a pull-request against the repository to edit `/src/links/v1/providers.json`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The repository is organized this way:
 - `/src/info/<version>/info.json` is the proper response to the info endpoint formatted according to OPTIMADE version `<version>` and any later version that uses a format that is backward compatible with this version.
 
 - `/src/index-metadbs/<provider_name>/<version>/info.json` and `/src/index-metadbs/<provider_name>/<version>/links.json` are static Index Meta-Databases that are hosted in this repository for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain one on their own.
-  See more details and instructions in `/src/index-metadbs/README.md`.
+  See more details and instructions in [`./src/index-metadbs/README.md`](./src/index-metadbs/README).
 
 - `/_redirects` specifies http rewrites to map index meta-database URLs `/<version>/info` and `/<version>/links` to the corresponding files under `src/`, as well as `/providers.json`.
   It also creates `/index-metadbs/<provider_name>/<version>/info.json` and `/index-metadbs/<provider_name>/<version>/links.json` URLs to point to the corresponding files in the `/src/index-metadbs` subfolders.
@@ -43,7 +43,7 @@ Hence, to update the list of providers, file a pull-request against the reposito
 
 ## Requirements to be listed in this providers list
 
-It is a policy of this providers list ([providers.optimade.org](http://providers.optimade.org)) that links inside `providers.json` must be links to an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#index-meta-database).
+It is a policy of this providers list ([providers.optimade.org](https://providers.optimade.org)) that links inside `providers.json` must be links to an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#index-meta-database).
 
 If you only have one or few databases in your implementation, and you do not want to host an Index Meta-Database yourself, you can host the Index Meta-Database directly in this repository.
 You can find instructions [here](./src/index-metadbs).

--- a/src/index-metadbs/README.md
+++ b/src/index-metadbs/README.md
@@ -4,7 +4,7 @@
 
 This folder hosts static versions of Index Meta-Databases for those providers that only have one main sub-database (or very few sub-databases) and do not wish to maintain an [OPTIMADE Index Meta-Database](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#index-meta-database) themselves.
 
-Note: while providing an Index Meta-Database is not required by the OPTIMADE API specification, it is instead required in order to be listed in this List of Providers ([providers.optimade.org](http://providers.optimade.org)).
+Note: while providing an Index Meta-Database is not required by the OPTIMADE API specification, it is instead required in order to be listed in this List of Providers ([providers.optimade.org](https://providers.optimade.org)).
 
 ## When should I use a static Index Meta-Database hosted in this repository
 
@@ -33,14 +33,14 @@ Note that "changes" here refer solely to changes to the *list of sub-databases*;
 3. Adapt the content of the `info.json` file.
    In particular, you should change two fields:
 
-   - change the URL of the `available_api_versions` by replacing `exmpl` with your identifier: `http://providers.optimade.org/index-metadbs/exmpl2/v1/`.
+   - change the URL of the `available_api_versions` by replacing `exmpl` with your identifier: `https://providers.optimade.org/index-metadbs/exmpl2/v1/`.
    - change the `id` inside `data -> relationships -> default -> data -> id` from `exmpl` to the correct ID from the list of links in the `links.json` file.
      As [explained in the OPTIMADE API specification](https://github.com/Materials-Consortia/OPTIMADE/blob/master/optimade.rst#base-info-endpoint), this should be the ID of the database that should be considered as the "default" sub-database by clients.
 
      If you only have one sub-database and you followed the instructions above, you should use here your provider identifier.
      If you do not wish to have a default database, set the `relationships` value to an empty dictionary or set the value of `relationships -> default -> data` to `null`.
 
-4. In the top-level `providers.json` file, point the `base_url` of your provider to `http://providers.optimade.org/index-metadbs/exmpl2/`.
+4. In the top-level `providers.json` file, point the `base_url` of your provider to `https://providers.optimade.org/index-metadbs/exmpl2/`.
 
 5. Create a pull request, and check that all automated continuous-integration tests pass.
    Also, you can check that the new Index Meta-Database properly works at the expected link using the Netlify preview (just click on the `netlify/optimade-providers/deploy-preview` entry of the GitHub checks that will appear in the GitHub PR Conversation page after a few seconds).

--- a/src/index-metadbs/aflow/v1/links.json
+++ b/src/index-metadbs/aflow/v1/links.json
@@ -14,8 +14,8 @@
          "attributes" : {
             "name": "AFLOW",
             "description": "The AFLOW OPTIMADE endpoint",
-            "base_url": "http://aflow.org/API/optimade/",
-            "homepage": "http://aflow.org",
+            "base_url": "https://aflow.org/API/optimade/",
+            "homepage": "https://aflow.org",
             "link_type": "child"
          }
       },

--- a/src/index-metadbs/ccpnc/v1/info.json
+++ b/src/index-metadbs/ccpnc/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/ccpnc/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/ccpnc/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/cmr/v1/info.json
+++ b/src/index-metadbs/cmr/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/cmr/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/cmr/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/cod/v1/info.json
+++ b/src/index-metadbs/cod/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/cod/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/cod/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/exmpl/v1/info.json
+++ b/src/index-metadbs/exmpl/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/exmpl/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/exmpl/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/jarvis/v1/info.json
+++ b/src/index-metadbs/jarvis/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/jarvis/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/jarvis/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/mp/v1/info.json
+++ b/src/index-metadbs/mp/v1/info.json
@@ -12,7 +12,7 @@
           "available_api_versions" : [
              {
                 "version" : "1.0.0",
-                "url" : "http://providers.optimade.org/index-metadbs/mp/v1/"
+                "url" : "https://providers.optimade.org/index-metadbs/mp/v1/"
              }
           ],
           "is_index" : true,

--- a/src/index-metadbs/mpdd/v1/info.json
+++ b/src/index-metadbs/mpdd/v1/info.json
@@ -12,7 +12,7 @@
           "available_api_versions" : [
              {
                 "version" : "1.0.0",
-                "url" : "http://providers.optimade.org/index-metadbs/mpdd/v1/"
+                "url" : "https://providers.optimade.org/index-metadbs/mpdd/v1/"
              }
           ],
           "is_index" : true,

--- a/src/index-metadbs/oqmd/v1/info.json
+++ b/src/index-metadbs/oqmd/v1/info.json
@@ -12,7 +12,7 @@
           "available_api_versions" : [
              {
                 "version" : "1.0.0",
-                "url" : "http://providers.optimade.org/index-metadbs/oqmd/v1/"
+                "url" : "https://providers.optimade.org/index-metadbs/oqmd/v1/"
              }
           ],
           "is_index" : true,

--- a/src/index-metadbs/oqmd/v1/links.json
+++ b/src/index-metadbs/oqmd/v1/links.json
@@ -14,8 +14,8 @@
             "attributes": {
                 "name": "The OQMD",
                 "description": "The Open Quantum Materials Database endpoint",
-                "base_url": "http://oqmd.org/optimade/",
-                "homepage": "http://oqmd.org",
+                "base_url": "https://oqmd.org/optimade/",
+                "homepage": "https://oqmd.org",
                 "link_type": "child"
             }
         },

--- a/src/index-metadbs/tcod/v1/info.json
+++ b/src/index-metadbs/tcod/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/tcod/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/tcod/v1/"
             }
          ],
          "is_index" : true,

--- a/src/index-metadbs/twodmatpedia/v1/info.json
+++ b/src/index-metadbs/twodmatpedia/v1/info.json
@@ -12,7 +12,7 @@
          "available_api_versions" : [
             {
                "version" : "1.0.0",
-               "url" : "http://providers.optimade.org/index-metadbs/twodmatpedia/v1/"
+               "url" : "https://providers.optimade.org/index-metadbs/twodmatpedia/v1/"
             }
          ],
          "is_index" : true,

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -15,7 +15,7 @@
         "name": "AiiDA",
         "description": "Automated Interactive Infrastructure and Database for Computational Science (AiiDA)",
         "base_url": null,
-        "homepage": "http://www.aiida.net",
+        "homepage": "https://www.aiida.net",
         "link_type": "external"
       }
     },
@@ -26,7 +26,7 @@
         "name": "AFLOW",
         "description": "Automatic FLOW (AFLOW) database for computational materials science",
         "base_url": "https://providers.optimade.org/index-metadbs/aflow",
-        "homepage": "http://aflow.org",
+        "homepage": "https://aflow.org",
         "link_type": "external"
       }
     },
@@ -37,7 +37,7 @@
         "name": "Alexandria",
         "description": "A collection of databases from the group of Prof Miguel A. L. Marques at Ruhr University Bochum.",
         "base_url": "https://providers.optimade.org/index-metadbs/alexandria",
-        "homepage": "http://tddft.org/bmg",
+        "homepage": "https://tddft.org/bmg",
         "link_type": "external"
       }
     },
@@ -47,7 +47,7 @@
       "attributes": {
         "name": "Crystallography Open Database",
         "description": "Open-access collection of crystal structures of organic, inorganic, metal-organic compounds and minerals, excluding biopolymers",
-        "base_url": "http://providers.optimade.org/index-metadbs/cod",
+        "base_url": "https://providers.optimade.org/index-metadbs/cod",
         "homepage": "https://www.crystallography.net/cod",
         "link_type": "external"
       }
@@ -69,7 +69,7 @@
       "attributes": {
         "name": "Computational materials repository (CMR)",
         "description": "CMR is a collection of materials repositories from different projects such as C2DB, QPOD and many more",
-        "base_url": "http://providers.optimade.org/index-metadbs/cmr",
+        "base_url": "https://providers.optimade.org/index-metadbs/cmr",
         "homepage": "https://cmr.fysik.dtu.dk",
         "link_type": "external"
       }
@@ -80,7 +80,7 @@
       "attributes": {
         "name": "Example provider",
         "description": "Provider used for examples, not to be assigned to a real database",
-        "base_url": "http://providers.optimade.org/index-metadbs/exmpl",
+        "base_url": "https://providers.optimade.org/index-metadbs/exmpl",
         "homepage": "https://example.com",
         "link_type": "external"
       }
@@ -124,7 +124,7 @@
       "attributes": {
         "name": "The Materials Project",
         "description": "An open database of computed materials properties to accelerate materials discovery and design",
-        "base_url": "http://providers.optimade.org/index-metadbs/mp",
+        "base_url": "https://providers.optimade.org/index-metadbs/mp",
         "homepage": "https://www.materialsproject.org",
         "link_type": "external"
       }
@@ -191,7 +191,7 @@
         "name": "Open Materials Database",
         "description": "The Open Materials Database (omdb) is a database of materials properties maintained by the developers of the High-Throughput Toolkit (httk). It enables easy access to useful materials data, in particular via programmatic interaction using this toolkit.",
         "base_url": "https://optimade-index.openmaterialsdb.se",
-        "homepage": "http://openmaterialsdb.se",
+        "homepage": "https://openmaterialsdb.se",
         "link_type": "external"
       }
     },
@@ -212,8 +212,8 @@
       "attributes": {
         "name": "The Open Quantum Materials Database (OQMD)",
         "description": "The OQMD is a database of DFT calculated thermodynamic and structural properties of materials",
-        "base_url": "http://providers.optimade.org/index-metadbs/oqmd",
-        "homepage": "http://oqmd.org",
+        "base_url": "https://providers.optimade.org/index-metadbs/oqmd",
+        "homepage": "https://oqmd.org",
         "link_type": "external"
       }
     },
@@ -223,7 +223,7 @@
       "attributes": {
         "name": "Joint Automated Repository for Various Integrated Simulations (JARVIS)",
         "description": "JARVIS is a repository designed to automate materials discovery using classical force-field, density functional theory, machine learning calculations and experiments.",
-        "base_url": "http://providers.optimade.org/index-metadbs/jarvis",
+        "base_url": "https://providers.optimade.org/index-metadbs/jarvis",
         "homepage": "https://jarvis.nist.gov",
         "link_type": "external"
       }
@@ -245,7 +245,7 @@
       "attributes": {
         "name": "Theoretical Crystallography Open Database",
         "description": "Open-access collection of theoretically calculated or refined crystal structures of organic, inorganic, metal-organic compounds and minerals, excluding biopolymers",
-        "base_url": "http://providers.optimade.org/index-metadbs/tcod",
+        "base_url": "https://providers.optimade.org/index-metadbs/tcod",
         "homepage": "https://www.crystallography.net/tcod",
         "link_type": "external"
       }
@@ -256,7 +256,7 @@
       "attributes": {
         "name": "2DMatpedia",
         "description": "2DMatpedia, an open computational database of two-dimensional materials from top-down and bottom-up approaches",
-        "base_url": "http://providers.optimade.org/index-metadbs/twodmatpedia",
+        "base_url": "https://providers.optimade.org/index-metadbs/twodmatpedia",
         "homepage": "http://2dmatpedia.org",
         "link_type": "external"
       }


### PR DESCRIPTION
This PR converts many links to https (and leaves those without certificates), especially our own internal provider links.