### PR TITLE
Update link for Alexandria

### DIFF
--- a/src/index-metadbs/alexandria/v1/links.json
+++ b/src/index-metadbs/alexandria/v1/links.json
@@ -14,8 +14,8 @@
          "attributes" : {
             "name": "alexandria",
             "description": "A new dataset of 415k stable and metastable materials calculated with the PBEsol and SCAN functionals",
-            "base_url": "https://alexandria.odbx.science",
-            "homepage": "https://doi.org/10.24435/materialscloud:5j-9m",
+            "base_url": "https://alexandria.icams.rub.de",
+            "homepage": "https://tddft.org/bmg/data.php",
             "link_type": "child"
          }
       },


### PR DESCRIPTION
Now `alexandria` is being hosted by its real group (@hyllio), we can update the link here.