### PR TITLE
update mcloud base_url

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -113,7 +113,7 @@
       "attributes": {
         "name": "Materials Cloud",
         "description": "A platform for Open Science built for seamless sharing of resources in computational materials science",
-        "base_url": "https://www.materialscloud.org/optimade",
+        "base_url": "https://www.materialscloud.org/optimade/main",
         "homepage": "https://www.materialscloud.org",
         "link_type": "external"
       }


### PR DESCRIPTION
Hi, we updated the mcloud provider's base_url to follow a similar pattern as the mcloudarchive provider. However, we will keep a redirect from the old base_url as well.