### PR TITLE
Rename necroptimade to optimake and update link

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -175,12 +175,12 @@
     },
     {
       "type": "links",
-      "id": "necro",
+      "id": "optimake",
       "attributes": {
-        "name": "NecrOPTIMADE",
-        "description": "A provider of ephemeral OPTIMADE APIs for static or archived data.",
+        "name": "optimake",
+        "description": "A tool for turning static data into OPTIMADE APIs",
         "base_url": null,
-        "homepage": "https://github.com/ml-evs/necroptimade",
+        "homepage": "https://github.com/materialscloud-org/optimade-maker",
         "link_type": "external"
       }
     },


### PR DESCRIPTION
NecrOPTIMADE is dead, long live NecrOPTIMADE, this PR replaces its unused namespace with the hot new optimade-maker, which is powering the Materials Cloud Archive's OPTIMADE integration (and potentially other local projects). This prefix will be used by default when ingesting archived data locally (so may appear in static JSONL files) so I think it makes sense to register it here.