### PR TITLE
Add AtomGPT.org provider

### DIFF
--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -321,7 +321,7 @@
       "id": "atomgpt",
       "attributes": {
         "name": "AtomGPT.org",
-        "description": "JARVIS-DFT materials database served via AtomGPT.org, providing OPTIMADE access alongside AI-based materials analysis tools",
+        "description": "Open OPTIMADE access (no account required) to the JARVIS-DFT materials database, hosted at AtomGPT.org alongside AI-based materials analysis tools",
         "base_url": "https://atomgpt.org/index/optimade",
         "homepage": "https://atomgpt.org",
         "link_type": "external"

--- a/src/links/v1/providers.json
+++ b/src/links/v1/providers.json
@@ -315,6 +315,17 @@
         "homepage": "http://2dmatpedia.org",
         "link_type": "external"
       }
+    },
+    {
+      "type": "links",
+      "id": "atomgpt",
+      "attributes": {
+        "name": "AtomGPT.org",
+        "description": "JARVIS-DFT materials database served via AtomGPT.org, providing OPTIMADE access alongside AI-based materials analysis tools",
+        "base_url": "https://atomgpt.org/index/optimade",
+        "homepage": "https://atomgpt.org",
+        "link_type": "external"
+      }
     }
   ]
 }


### PR DESCRIPTION
AtomGPT.org serves the JARVIS-DFT database via a public, validator-passing OPTIMADE 1.1 endpoint (https://atomgpt.org/optimade/v1) with a self-hosted index meta-database at https://atomgpt.org/index/optimade.

Both endpoints pass the official optimade-validator (main: 41/41 + 7/7 optional; index: 8/8 + 3/3 optional).

Note: this is a distinct provider id from the existing NIST 'jarvis' entry - it exposes JARVIS-DFT data through the AtomGPT.org platform.